### PR TITLE
Feature 2 development issue_templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,77 @@
+---
+name: Bug report
+about: Fix something that's not working
+title: ''
+labels: 'type: bug'
+assignees: ''
+
+---
+
+*Replace italics below with details for this issue.*
+
+## Describe the Problem ##
+*Provide a clear and concise description of the bug here.*
+
+### Expected Behavior ###
+*Provide a clear and concise description of what you expected to happen here.*
+
+### Environment ###
+Describe your runtime environment:
+*1. Machine: (e.g. HPC name, Linux Workstation, Mac Laptop)*
+*2. OS: (e.g. RedHat Linux, MacOS)*
+*3. Software version number(s)*
+
+### To Reproduce ###
+Describe the steps to reproduce the behavior:
+*1. Go to '...'*
+*2. Click on '....'*
+*3. Scroll down to '....'*
+*4. See error*
+*Post relevant sample data following these instructions:*
+*https://dtcenter.org/community-code/model-evaluation-tools-met/met-help-desk#ftp*
+
+### Relevant Deadlines ###
+*List relevant project deadlines here or state NONE.*
+
+### Funding Source ###
+*Define the source of funding and account keys here or state NONE.*
+
+## Define the Metadata ##
+
+### Assignee ###
+- [ ] Select **engineer(s)** or **no engineer** required
+- [ ] Select **scientist(s)** or **no scientist** required
+
+### Labels ###
+- [ ] Select **component(s)**
+- [ ] Select **priority**
+- [ ] Select **requestor(s)**
+
+### Projects and Milestone ###
+- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
+- [ ] Select **milestone** to relevant bugfix version
+
+## Define Related Issue(s) ##
+Consider the impact to the other METplus components.
+- [ ] [METplus](https://github.com/dtcenter/METplus/issues/new/choose), [MET](https://github.com/dtcenter/MET/issues/new/choose), [METdatadb](https://github.com/dtcenter/METdatadb/issues/new/choose), [METviewer](https://github.com/dtcenter/METviewer/issues/new/choose), [METexpress](https://github.com/dtcenter/METexpress/issues/new/choose), [METcalcpy](https://github.com/dtcenter/METcalcpy/issues/new/choose), [METplotpy](https://github.com/dtcenter/METplotpy/issues/new/choose)
+
+## Bugfix Checklist ##
+See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
+- [ ] Complete the issue definition above, including the **Time Estimate** and **Funding Source**.
+- [ ] Fork this repository or create a branch of **master**.
+Branch name: `bugfix_<Issue Number>_master_<Description>`
+- [ ] Fix the bug and test your changes.
+- [ ] Add/update log messages for easier debugging.
+- [ ] Add/update unit tests.
+- [ ] Add/update documentation.
+- [ ] Push local changes to GitHub.
+- [ ] Submit a pull request to merge into **master**.
+Pull request: `bugfix <Issue Number> master <Description>`
+- [ ] Define the pull request metadata, as permissions allow.
+Select: **Reviewer(s)**, **Project(s)**, **Milestone**, and **Linked issues**
+- [ ] Iterate until the reviewer(s) accept and merge your changes.
+- [ ] Delete your fork or branch.
+- [ ] Complete the steps above to fix the bug on the **development** branch.
+Branch name:  `bugfix_<Issue Number>_development_<Description>`
+Pull request: `bugfix <Issue Number> development <Description>`
+- [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,64 @@
+---
+name: Enhancement request
+about: Improve something that it's currently doing
+title: ''
+labels: 'type: enhancement'
+assignees: ''
+
+---
+
+*Replace italics below with details for this issue.*
+
+## Describe the Enhancement ##
+*Provide a description of the enhancement request here.*
+
+### Time Estimate ###
+*Estimate the amount of work required here.*
+*Issues should represent approximately 1 to 3 days of work.*
+
+### Sub-Issues ###
+Consider breaking the enhancement down into sub-issues.
+- [ ] *Add a checkbox for each sub-issue here.*
+
+### Relevant Deadlines ###
+*List relevant project deadlines here or state NONE.*
+
+### Funding Source ###
+*Define the source of funding and account keys here or state NONE.*
+
+## Define the Metadata ##
+
+### Assignee ###
+- [ ] Select **engineer(s)** or **no engineer** required
+- [ ] Select **scientist(s)** or **no scientist** required
+
+### Labels ###
+- [ ] Select **component(s)**
+- [ ] Select **priority**
+- [ ] Select **requestor(s)**
+
+### Projects and Milestone ###
+- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
+- [ ] Select **milestone** to next major version milestone or "Future Versions"
+
+## Define Related Issue(s) ##
+Consider the impact to the other METplus components.
+- [ ] [METplus](https://github.com/dtcenter/METplus/issues/new/choose), [MET](https://github.com/dtcenter/MET/issues/new/choose), [METdatadb](https://github.com/dtcenter/METdatadb/issues/new/choose), [METviewer](https://github.com/dtcenter/METviewer/issues/new/choose), [METexpress](https://github.com/dtcenter/METexpress/issues/new/choose), [METcalcpy](https://github.com/dtcenter/METcalcpy/issues/new/choose), [METplotpy](https://github.com/dtcenter/METplotpy/issues/new/choose)
+
+## Enhancement Checklist ##
+See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
+- [ ] Complete the issue definition above, including the **Time Estimate** and **Funding Source**.
+- [ ] Fork this repository or create a branch of **development**.
+Branch name: `feature_<Issue Number>_<Description>`
+- [ ] Complete the development and test your changes.
+- [ ] Add/update log messages for easier debugging.
+- [ ] Add/update unit tests.
+- [ ] Add/update documentation.
+- [ ] Push local changes to GitHub.
+- [ ] Submit a pull request to merge into **development**.
+Pull request: `feature <Issue Number> <Description>`
+- [ ] Define the pull request metadata, as permissions allow.
+Select: **Reviewer(s)**, **Project(s)**, **Milestone**, and **Linked issues**
+- [ ] Iterate until the reviewer(s) accept and merge your changes.
+- [ ] Delete your fork or branch.
+- [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/new_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/new_feature_request.md
@@ -1,0 +1,68 @@
+---
+name: New feature request
+about: Make it do something new
+title: ''
+labels: 'type: new feature'
+assignees: ''
+
+---
+
+*Replace italics below with details for this issue.*
+
+## Describe the New Feature ##
+*Provide a description of the new feature request here.*
+
+### Acceptance Testing ###
+*List input data types and sources.*
+*Describe tests required for new functionality.*
+
+### Time Estimate ###
+*Estimate the amount of work required here.*
+*Issues should represent approximately 1 to 3 days of work.*
+
+### Sub-Issues ###
+Consider breaking the new feature down into sub-issues.
+- [ ] *Add a checkbox for each sub-issue here.*
+
+### Relevant Deadlines ###
+*List relevant project deadlines here or state NONE.*
+
+### Funding Source ###
+*Define the source of funding and account keys here or state NONE.*
+
+## Define the Metadata ##
+
+### Assignee ###
+- [ ] Select **engineer(s)** or **no engineer** required
+- [ ] Select **scientist(s)** or **no scientist** required
+
+### Labels ###
+- [ ] Select **component(s)**
+- [ ] Select **priority**
+- [ ] Select **requestor(s)**
+
+### Projects and Milestone ###
+- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
+- [ ] Select **milestone** to next major version milestone or "Future Versions"
+
+## Define Related Issue(s) ##
+Consider the impact to the other METplus components.
+- [ ] [METplus](https://github.com/dtcenter/METplus/issues/new/choose), [MET](https://github.com/dtcenter/MET/issues/new/choose), [METdatadb](https://github.com/dtcenter/METdatadb/issues/new/choose), [METviewer](https://github.com/dtcenter/METviewer/issues/new/choose), [METexpress](https://github.com/dtcenter/METexpress/issues/new/choose), [METcalcpy](https://github.com/dtcenter/METcalcpy/issues/new/choose), [METplotpy](https://github.com/dtcenter/METplotpy/issues/new/choose)
+
+## New Feature Checklist ##
+See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
+- [ ] Complete the issue definition above, including the **Time Estimate** and **Funding source**.
+- [ ] Fork this repository or create a branch of **development**.
+Branch name: `feature_<Issue Number>_<Description>`
+- [ ] Complete the development and test your changes.
+- [ ] Add/update log messages for easier debugging.
+- [ ] Add/update unit tests.
+- [ ] Add/update documentation.
+- [ ] Push local changes to GitHub.
+- [ ] Submit a pull request to merge into **development**.
+Pull request: `feature <Issue Number> <Description>`
+- [ ] Define the pull request metadata, as permissions allow.
+Select: **Reviewer(s)**, **Project(s)**, **Milestone**, and **Linked issues**
+- [ ] Iterate until the reviewer(s) accept and merge your changes.
+- [ ] Delete your fork or branch.
+- [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/sub-issue.md
+++ b/.github/ISSUE_TEMPLATE/sub-issue.md
@@ -1,0 +1,32 @@
+---
+name: Sub-Issue
+about: Break an issue down into smaller parts
+title: ''
+labels: 'type: sub-issue'
+assignees: ''
+
+---
+
+This is a sub-issue of #*List the parent issue number here*.
+
+## Describe the Sub-Issue ##
+*Provide a description of the sub-issue here.*
+
+### Time Estimate ###
+*Estimate the amount of work required here.*
+*Issues should represent approximately 1 to 3 days of work.*
+
+## Define the Metadata ##
+
+### Assignee ###
+- [ ] Select **engineer(s)** or **no engineer** required
+- [ ] Select **scientist(s)** or **no scientist** required
+
+### Labels ###
+- [ ] Select **component(s)**
+- [ ] Select **priority**
+- [ ] Select **requestor(s)**
+
+### Projects and Milestone ###
+- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
+- [ ] Select **milestone** to next major version milestone or "Future Versions"

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,64 @@
+---
+name: Task
+about: Describe something that needs to be done
+title: ''
+labels: 'type: task'
+assignees: ''
+
+---
+
+*Replace italics below with details for this issue.*
+
+## Describe the Task ##
+*Provide a description of the task here.*
+
+### Time Estimate ###
+*Estimate the amount of work required here.*
+*Issues should represent approximately 1 to 3 days of work.*
+
+### Sub-Issues ###
+Consider breaking the task down into sub-issues.
+- [ ] *Add a checkbox for each sub-issue here.*
+
+### Relevant Deadlines ###
+*List relevant project deadlines here or state NONE.*
+
+### Funding Source ###
+*Define the source of funding and account keys here or state NONE.*
+
+## Define the Metadata ##
+
+### Assignee ###
+- [ ] Select **engineer(s)** or **no engineer** required
+- [ ] Select **scientist(s)** or **no scientist** required
+
+### Labels ###
+- [ ] Select **component(s)**
+- [ ] Select **priority**
+- [ ] Select **requestor(s)**
+
+### Projects and Milestone ###
+- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
+- [ ] Select **milestone** to next major version milestone or "Future Versions"
+
+## Define Related Issue(s) ##
+Consider the impact to the other METplus components.
+- [ ] [METplus](https://github.com/dtcenter/METplus/issues/new/choose), [MET](https://github.com/dtcenter/MET/issues/new/choose), [METdatadb](https://github.com/dtcenter/METdatadb/issues/new/choose), [METviewer](https://github.com/dtcenter/METviewer/issues/new/choose), [METexpress](https://github.com/dtcenter/METexpress/issues/new/choose), [METcalcpy](https://github.com/dtcenter/METcalcpy/issues/new/choose), [METplotpy](https://github.com/dtcenter/METplotpy/issues/new/choose)
+
+## Task Checklist ##
+See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
+- [ ] Complete the issue definition above, including the **Time Estimate** and **Funding Source**.
+- [ ] Fork this repository or create a branch of **development**.
+Branch name: `feature_<Issue Number>_<Description>`
+- [ ] Complete the development and test your changes.
+- [ ] Add/update log messages for easier debugging.
+- [ ] Add/update unit tests.
+- [ ] Add/update documentation.
+- [ ] Push local changes to GitHub.
+- [ ] Submit a pull request to merge into **development**.
+Pull request: `feature <Issue Number> <Description>`
+- [ ] Define the pull request metadata, as permissions allow.
+Select: **Reviewer(s)**, **Project(s)**, **Milestone**, and **Linked issues**
+- [ ] Iterate until the reviewer(s) accept and merge your changes.
+- [ ] Delete your fork or branch.
+- [ ] Close this issue.


### PR DESCRIPTION
Add GitHub issue templates to the development branch.
Please see issue #2 for details.
Technically, these are only required on the default branch of the GitHub repo, which is master. But if you're merging code from development into master, I suspect it'll be convenient to have them in both branches to avoid potential diffs being flagged.