### PR TITLE
Moved defaults to settings and removed redundancies with main.js files.

### DIFF
--- a/apps/met-airquality/server/main.js
+++ b/apps/met-airquality/server/main.js
@@ -481,16 +481,12 @@ const doCurveParams = function () {
         );
     }
 
-    var defaultGroup;
-    if (Object.keys(dbGroupMap).indexOf("pshafran") !== -1) {
-        // special default parameters for the NWS METexpress
-        defaultGroup = "pshafran";
-    } else {
-        // default to the GSL test database if it exists. Currently a placeholder for GSL.
-        defaultGroup = (Object.keys(dbGroupMap).indexOf("Test12") !== -1) ? "Test12" : Object.keys(dbGroupMap)[0];
-    }
-    var defaultDB = dbGroupMap[defaultGroup][0];
-    var defaultModel = Object.keys(modelOptionsMap[defaultDB])[0];
+    var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
+    var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
+    var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
+    var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
+    var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
+    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -1407,31 +1403,8 @@ Meteor.startup(function () {
 
     // create list of tables we need to monitor for update
     const mdr = new matsTypes.MetaDataDBRecord("sumPool", "mats_metadata", ['airquality_mats_metadata', 'airquality_database_groups']);
-    const appCurveParams = [
-        "label",
-        "group",
-        "database",
-        "data-source",
-        "plot-type",
-        "region",
-        "statistic",
-        "variable",
-        "threshold",
-        "interp-method",
-        "scale",
-        "forecast-length",
-        "dieoff-type",
-        "valid-time",
-        "utc-cycle-start",
-        "average",
-        "level",
-        "description",
-        "x-axis-parameter",
-        "y-axis-parameter",
-        "curve-dates"
-    ];
     try {
-        matsMethods.resetApp({appPools: allPools, appCurveParams: appCurveParams, appMdr: mdr, appType: matsTypes.AppTypes.metexpress, app: 'met-airquality', title: "MET Air Quality", group: "METexpress"});
+        matsMethods.resetApp({appPools: allPools, appMdr: mdr, appType: matsTypes.AppTypes.metexpress});
     } catch (error) {
         console.log(error.message);
     }

--- a/apps/met-airquality/server/main.js
+++ b/apps/met-airquality/server/main.js
@@ -480,13 +480,16 @@ const doCurveParams = function () {
             }
         );
     }
-
+    // get the default group, db, and model that were specified in the settings file. If none exist, take
+    // the first available option for each in the selector.
     var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
     var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
     var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
     var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
     var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
     var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
+
+    // these defaults are app-specific and not controlled by the user
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -625,6 +628,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const regionOptions = regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var regionDefault;
     if (regionOptions.indexOf("FULL") !== -1) {
@@ -830,6 +834,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const fhrOptions = forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var fhrDefault;
     if (fhrOptions.indexOf("24") !== -1) {
@@ -968,6 +973,7 @@ const doCurveParams = function () {
             });
     }
 
+    // these defaults are app-specific and not controlled by the user
     const levelOptions = levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var levelDefault;
     if (levelOptions.indexOf("SFC") !== -1) {
@@ -1100,6 +1106,7 @@ const doCurveParams = function () {
     }
 
     // determine date defaults for dates and curveDates
+    // these defaults are app-specific and not controlled by the user
     var defaultDb = matsCollections["database"].findOne({name: "database"}, {default: 1}).default;
     var dbDateRanges = matsCollections["database"].findOne({name: "database"}, {dates: 1}).dates;
     var defaultDataSource = matsCollections["data-source"].findOne({name: "data-source"}, {default: 1}).default;

--- a/apps/met-anomalycor/server/main.js
+++ b/apps/met-anomalycor/server/main.js
@@ -449,18 +449,12 @@ const doCurveParams = function () {
         );
     }
 
-    var defaultGroup;
-    var defaultDB;
-    if (Object.keys(dbGroupMap).indexOf("NOAA NCEP") !== -1 && dbGroupMap["NOAA NCEP"].indexOf("mv_gfs_grid2grid_metplus") !== -1) {
-        // special default parameters for the NWS METexpress
-        defaultGroup = "NOAA NCEP";
-        defaultDB = "mv_gfs_grid2grid_metplus";
-    } else {
-        // default to the GSL g2g database if it exists, otherwise default to whatever is first alphabetically
-        defaultGroup = (Object.keys(dbGroupMap).indexOf("NO GROUP") !== -1) ? "NO GROUP" : Object.keys(dbGroupMap)[0];
-        defaultDB = (dbGroupMap[defaultGroup].indexOf("mv_gsl_global_g2g") !== -1) ? "mv_gsl_global_g2g" : dbGroupMap[defaultGroup][0];
-    }
-    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("GFS") !== -1) ? "GFS" : Object.keys(modelOptionsMap[defaultDB])[0];
+    var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
+    var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
+    var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
+    var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
+    var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
+    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -1342,30 +1336,8 @@ Meteor.startup(function () {
 
     // create list of tables we need to monitor for update
     const mdr = new matsTypes.MetaDataDBRecord("sumPool", "mats_metadata", ['anomalycor_mats_metadata', 'anomalycor_database_groups']);
-    const appCurveParams = [
-        "label",
-        "group",
-        "database",
-        "data-source",
-        "plot-type",
-        "region",
-        "statistic",
-        "variable",
-        "interp-method",
-        "scale",
-        "forecast-length",
-        "dieoff-type",
-        "valid-time",
-        "utc-cycle-start",
-        "average",
-        "level",
-        "description",
-        "x-axis-parameter",
-        "y-axis-parameter",
-        "curve-dates"
-    ];
     try {
-        matsMethods.resetApp({ appPools: allPools, appCurveParams: appCurveParams, appMdr: mdr, appType: matsTypes.AppTypes.metexpress, app: 'met-anomalycor', title: "MET Anomaly Correlation", group: "METexpress"});
+        matsMethods.resetApp({appPools: allPools, appMdr: mdr, appType: matsTypes.AppTypes.metexpress});
     } catch (error) {
         console.log(error.message);
     }

--- a/apps/met-anomalycor/server/main.js
+++ b/apps/met-anomalycor/server/main.js
@@ -448,13 +448,16 @@ const doCurveParams = function () {
             }
         );
     }
-
+    // get the default group, db, and model that were specified in the settings file. If none exist, take
+    // the first available option for each in the selector.
     var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
     var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
     var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
     var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
     var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
     var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
+
+    // these defaults are app-specific and not controlled by the user
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -593,6 +596,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const regionOptions = regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var regionDefault;
     if (regionOptions.indexOf("FULL") !== -1) {
@@ -670,6 +674,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const variableOptions = variableOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType];
     var variableDefault;
     if (variableOptions.indexOf("HGT") !== -1) {
@@ -775,6 +780,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const fhrOptions = forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var fhrDefault;
     if (fhrOptions.indexOf("120") !== -1) {
@@ -913,6 +919,7 @@ const doCurveParams = function () {
             });
     }
 
+    // these defaults are app-specific and not controlled by the user
     const levelOptions = levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var levelDefault;
     if (levelOptions.indexOf("P500") !== -1) {
@@ -1041,6 +1048,7 @@ const doCurveParams = function () {
     }
 
     // determine date defaults for dates and curveDates
+    // these defaults are app-specific and not controlled by the user
     var defaultDb = matsCollections["database"].findOne({name: "database"}, {default: 1}).default;
     var dbDateRanges = matsCollections["database"].findOne({name: "database"}, {dates: 1}).dates;
     var defaultDataSource = matsCollections["data-source"].findOne({name: "data-source"}, {default: 1}).default;

--- a/apps/met-cyclone/server/main.js
+++ b/apps/met-cyclone/server/main.js
@@ -886,13 +886,16 @@ const doCurveParams = function () {
             }
         );
     }
-
+    // get the default group, db, and model that were specified in the settings file. If none exist, take
+    // the first available option for each in the selector.
     var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
     var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
     var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
     var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
     var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
     var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
+
+    // these defaults are app-specific and not controlled by the user
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -1031,6 +1034,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const basinOptions = basinOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType];
     var defaultBasin;
     if (basinOptions.indexOf("AL") !== -1) {
@@ -1105,6 +1109,7 @@ const doCurveParams = function () {
     }
 
     // display most recent year as default
+    // these defaults are app-specific and not controlled by the user
     const defaultYear = yearOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][defaultBasin][0];
     
     if (matsCollections["year"].findOne({name: 'year'}) == undefined) {
@@ -1203,6 +1208,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const fhrOptions = forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][defaultBasin][defaultYear];
     var fhrDefault;
     if (fhrOptions.indexOf("24") !== -1) {
@@ -1410,6 +1416,7 @@ const doCurveParams = function () {
     }
 
     // determine date defaults for dates and curveDates
+    // these defaults are app-specific and not controlled by the user
     var defaultDb = matsCollections["database"].findOne({name: "database"}, {default: 1}).default;
     var dbDateRanges = matsCollections["database"].findOne({name: "database"}, {dates: 1}).dates;
     var defaultDataSource = matsCollections["data-source"].findOne({name: "data-source"}, {default: 1}).default;

--- a/apps/met-cyclone/server/main.js
+++ b/apps/met-cyclone/server/main.js
@@ -887,28 +887,12 @@ const doCurveParams = function () {
         );
     }
 
-    var defaultGroup;
-    var defaultDB;
-    var defaultModel;
-    if (Object.keys(dbGroupMap).indexOf("NO GROUP") !== -1 && dbGroupMap["NO GROUP"].indexOf("mv_dev_python") !== -1) {
-        // special default parameters for the NWS METexpress -- placeholder until someone loads something better
-        defaultGroup = "NO GROUP";
-        defaultDB = "mv_dev_python";
-        defaultModel = Object.keys(modelOptionsMap[defaultDB])[0];
-    } else {
-        // default to the GSL realtime TC database if it exists, otherwise default to whatever is first alphabetically
-        defaultGroup = (Object.keys(dbGroupMap).indexOf("realtime_tc_verif") !== -1) ? "realtime_tc_verif" : Object.keys(dbGroupMap)[0];
-        if (dbGroupMap[defaultGroup].indexOf("mv_gsl_tcmet_post") !== -1) {
-            defaultDB = "mv_gsl_tcmet_post";
-            defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("GF16") !== -1) ? "GF16" : Object.keys(modelOptionsMap[defaultDB])[0];
-        } else if (dbGroupMap[defaultGroup].indexOf("mv_nhc_tcmet_post") !== -1) {
-            defaultDB = "mv_nhc_tcmet_post";
-            defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("GFSO: GFS") !== -1) ? "GFSO: GFS" : Object.keys(modelOptionsMap[defaultDB])[0];
-        } else {
-            defaultDB = dbGroupMap[defaultGroup][0];
-            defaultModel = Object.keys(modelOptionsMap[defaultDB])[0];
-        }
-    }
+    var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
+    var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
+    var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
+    var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
+    var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
+    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -1692,28 +1676,8 @@ Meteor.startup(function () {
 
     // create list of tables we need to monitor for update
     const mdr = new matsTypes.MetaDataDBRecord("sumPool", "mats_metadata", ['cyclone_mats_metadata', 'cyclone_database_groups']);
-    const appCurveParams = [
-        "label",
-        "group",
-        "database",
-        "data-source",
-        "plot-type",
-        "basin",
-        "statistic",
-        "year",
-        "storm",
-        "truth",
-        "forecast-length",
-        "dieoff-type",
-        "valid-time",
-        "utc-cycle-start",
-        "average",
-        "level",
-        "description",
-        "curve-dates"
-    ];
     try {
-        matsMethods.resetApp({ appPools: allPools, appCurveParams: appCurveParams, appMdr: mdr, appType: matsTypes.AppTypes.metexpress, app: 'met-cyclone', title: "MET Cyclone", group: "METexpress"});
+        matsMethods.resetApp({appPools: allPools, appMdr: mdr, appType: matsTypes.AppTypes.metexpress});
     } catch (error) {
         console.log(error.message);
     }

--- a/apps/met-ensemble/server/main.js
+++ b/apps/met-ensemble/server/main.js
@@ -478,20 +478,12 @@ const doCurveParams = function () {
         );
     }
 
-    var defaultGroup;
-    var defaultDB;
-    var defaultModel;
-    if (Object.keys(dbGroupMap).indexOf("NCEP Binbin") !== -1 && dbGroupMap["NCEP Binbin"].indexOf("mv_met_g2o_gefs") !== -1) {
-        // special default parameters for the NWS METexpress
-        defaultGroup = "NCEP Binbin";
-        defaultDB = "mv_met_g2o_gefs";
-        defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("GEFS") !== -1) ? "GEFS" : Object.keys(modelOptionsMap[defaultDB])[0];
-    } else {
-        // default to the GSL realtime ensemble database if it exists, otherwise default to whatever is first alphabetically
-        defaultGroup = (Object.keys(dbGroupMap).indexOf("NO GROUP") !== -1) ? "NO GROUP" : Object.keys(dbGroupMap)[0];
-        defaultDB = (dbGroupMap[defaultGroup].indexOf("mv_gsd_ensemble_realtime") !== -1) ? "mv_gsd_ensemble_realtime" : dbGroupMap[defaultGroup][0];
-        defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("RRFSE") !== -1) ? "RRFSE" : Object.keys(modelOptionsMap[defaultDB])[0];
-    }
+    var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
+    var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
+    var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
+    var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
+    var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
+    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -1294,26 +1286,8 @@ Meteor.startup(function () {
 
     // create list of tables we need to monitor for update
     const mdr = new matsTypes.MetaDataDBRecord("sumPool", "mats_metadata", ['ensemble_mats_metadata', 'ensemble_database_groups']);
-    const appCurveParams = [
-        "label",
-        "group",
-        "database",
-        "data-source",
-        "plot-type",
-        "region",
-        "statistic",
-        "variable",
-        "forecast-length",
-        "dieoff-type",
-        "valid-time",
-        "utc-cycle-start",
-        "average",
-        "level",
-        "description",
-        "curve-dates"
-    ];
     try {
-        matsMethods.resetApp({ appPools: allPools, appCurveParams: appCurveParams, appMdr: mdr, appType: matsTypes.AppTypes.metexpress, app: 'met-ensemble', title: "MET Ensemble", group: "METexpress"});
+        matsMethods.resetApp({appPools: allPools, appMdr: mdr, appType: matsTypes.AppTypes.metexpress});
     } catch (error) {
         console.log(error.message);
     }

--- a/apps/met-ensemble/server/main.js
+++ b/apps/met-ensemble/server/main.js
@@ -477,13 +477,16 @@ const doCurveParams = function () {
             }
         );
     }
-
+    // get the default group, db, and model that were specified in the settings file. If none exist, take
+    // the first available option for each in the selector.
     var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
     var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
     var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
     var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
     var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
     var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
+
+    // these defaults are app-specific and not controlled by the user
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -622,6 +625,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const regionOptions = regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var regionDefault;
     if (regionOptions.indexOf("FULL") !== -1) {
@@ -699,6 +703,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const variableOptions = variableOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType];
     var variableDefault;
     if (variableOptions.indexOf("PROB(APCP_06>12_700)") !== -1) {
@@ -742,6 +747,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const fhrOptions = forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var fhrDefault;
     if (fhrOptions.indexOf("24") !== -1) {
@@ -880,6 +886,7 @@ const doCurveParams = function () {
             });
     }
 
+    // these defaults are app-specific and not controlled by the user
     const levelOptions = levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var levelDefault;
     if (levelOptions.indexOf("A06") !== -1) {
@@ -956,6 +963,7 @@ const doCurveParams = function () {
     }
 
     // determine date defaults for dates and curveDates
+    // these defaults are app-specific and not controlled by the user
     var defaultDb = matsCollections["database"].findOne({name: "database"}, {default: 1}).default;
     var dbDateRanges = matsCollections["database"].findOne({name: "database"}, {dates: 1}).dates;
     var defaultDataSource = matsCollections["data-source"].findOne({name: "data-source"}, {default: 1}).default;

--- a/apps/met-precip/server/main.js
+++ b/apps/met-precip/server/main.js
@@ -503,20 +503,12 @@ const doCurveParams = function () {
         );
     }
 
-    var defaultGroup;
-    var defaultDB;
-    var defaultModel;
-    if (Object.keys(dbGroupMap).indexOf("NOAA NCEP") !== -1 && dbGroupMap["NOAA NCEP"].indexOf("mv_gfs_precip_metplus") !== -1) {
-        // special default parameters for the NWS METexpress
-        defaultGroup = "NOAA NCEP";
-        defaultDB = "mv_gfs_precip_metplus";
-        defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("gfs") !== -1) ? "gfs" : Object.keys(modelOptionsMap[defaultDB])[0];
-    } else {
-        // default to the 2018 HWT precip database if it exists. Currently a placeholder for GSL.
-        defaultGroup = (Object.keys(dbGroupMap).indexOf("NO GROUP") !== -1) ? "NO GROUP" : Object.keys(dbGroupMap)[0];
-        defaultDB = (dbGroupMap[defaultGroup].indexOf("mv_hwt_2018") !== -1) ? "mv_hwt_2018" : dbGroupMap[defaultGroup][0];
-        defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("HRRR") !== -1) ? "HRRR" : Object.keys(modelOptionsMap[defaultDB])[0];
-    }
+    var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
+    var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
+    var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
+    var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
+    var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
+    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -1500,32 +1492,8 @@ Meteor.startup(function () {
 
     // create list of tables we need to monitor for update
     const mdr = new matsTypes.MetaDataDBRecord("sumPool", "mats_metadata", ['precip_mats_metadata', 'precip_database_groups']);
-    const appCurveParams = [
-        "label",
-        "group",
-        "database",
-        "data-source",
-        "plot-type",
-        "region",
-        "statistic",
-        "variable",
-        "threshold",
-        "interp-method",
-        "scale",
-        "truth",
-        "forecast-length",
-        "dieoff-type",
-        "valid-time",
-        "utc-cycle-start",
-        "average",
-        "level",
-        "description",
-        "x-axis-parameter",
-        "y-axis-parameter",
-        "curve-dates"
-    ];
     try {
-        matsMethods.resetApp({ appPools: allPools, appCurveParams: appCurveParams, appMdr: mdr, appType: matsTypes.AppTypes.metexpress, app: 'met-precip', title: "MET Precipitation", group: "METexpress"});
+        matsMethods.resetApp({appPools: allPools, appMdr: mdr, appType: matsTypes.AppTypes.metexpress});
     } catch (error) {
         console.log(error.message);
     }

--- a/apps/met-precip/server/main.js
+++ b/apps/met-precip/server/main.js
@@ -502,13 +502,16 @@ const doCurveParams = function () {
             }
         );
     }
-
+    // get the default group, db, and model that were specified in the settings file. If none exist, take
+    // the first available option for each in the selector.
     var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
     var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
     var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
     var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
     var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
     var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
+
+    // these defaults are app-specific and not controlled by the user
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -647,6 +650,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const regionOptions = regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var regionDefault;
     if (regionOptions.indexOf("FULL") !== -1) {
@@ -886,6 +890,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const fhrOptions = forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var fhrDefault;
     if (fhrOptions.indexOf("24") !== -1) {
@@ -1024,6 +1029,7 @@ const doCurveParams = function () {
             });
     }
 
+    // these defaults are app-specific and not controlled by the user
     const levelOptions = levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var levelDefault;
     if (levelOptions.indexOf("L0") !== -1) {
@@ -1156,6 +1162,7 @@ const doCurveParams = function () {
     }
 
     // determine date defaults for dates and curveDates
+    // these defaults are app-specific and not controlled by the user
     var defaultDb = matsCollections["database"].findOne({name: "database"}, {default: 1}).default;
     var dbDateRanges = matsCollections["database"].findOne({name: "database"}, {dates: 1}).dates;
     var defaultDataSource = matsCollections["data-source"].findOne({name: "data-source"}, {default: 1}).default;

--- a/apps/met-surface/server/main.js
+++ b/apps/met-surface/server/main.js
@@ -481,18 +481,12 @@ const doCurveParams = function () {
         );
     }
 
-    var defaultGroup;
-    var defaultDB;
-    if (Object.keys(dbGroupMap).indexOf("NOAA NCEP") !== -1 && dbGroupMap["NOAA NCEP"].indexOf("mv_gfs_grid2grid_metplus") !== -1) {
-        // special default parameters for the NWS METexpress
-        defaultGroup = "NOAA NCEP";
-        defaultDB = "mv_gfs_grid2grid_metplus";
-    } else {
-        // default to the GSL g2g database if it exists, otherwise default to whatever is first alphabetically
-        defaultGroup = (Object.keys(dbGroupMap).indexOf("NO GROUP") !== -1) ? "NO GROUP" : Object.keys(dbGroupMap)[0];
-        defaultDB = (dbGroupMap[defaultGroup].indexOf("mv_gsl_global_g2g") !== -1) ? "mv_gsl_global_g2g" : dbGroupMap[defaultGroup][0];
-    }
-    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("GFS") !== -1) ? "GFS" : Object.keys(modelOptionsMap[defaultDB])[0];
+    var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
+    var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
+    var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
+    var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
+    var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
+    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -1349,30 +1343,8 @@ Meteor.startup(function () {
 
     // create list of tables we need to monitor for update
     const mdr = new matsTypes.MetaDataDBRecord("sumPool", "mats_metadata", ['surface_mats_metadata', 'surface_database_groups']);
-    const appCurveParams = [
-        "label",
-        "group",
-        "database",
-        "data-source",
-        "plot-type",
-        "region",
-        "statistic",
-        "variable",
-        "interp-method",
-        "scale",
-        "forecast-length",
-        "dieoff-type",
-        "valid-time",
-        "utc-cycle-start",
-        "average",
-        "level",
-        "description",
-        "x-axis-parameter",
-        "y-axis-parameter",
-        "curve-dates"
-    ];
     try {
-        matsMethods.resetApp({ appPools: allPools, appCurveParams: appCurveParams, appMdr: mdr, appType: matsTypes.AppTypes.metexpress, app: 'met-surface', title: "MET Surface", group: "METexpress"});
+        matsMethods.resetApp({appPools: allPools, appMdr: mdr, appType: matsTypes.AppTypes.metexpress});
     } catch (error) {
         console.log(error.message);
     }

--- a/apps/met-surface/server/main.js
+++ b/apps/met-surface/server/main.js
@@ -480,13 +480,16 @@ const doCurveParams = function () {
             }
         );
     }
-
+    // get the default group, db, and model that were specified in the settings file. If none exist, take
+    // the first available option for each in the selector.
     var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
     var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
     var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
     var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
     var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
     var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
+
+    // these defaults are app-specific and not controlled by the user
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -625,6 +628,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const regionOptions = regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var regionDefault;
     if (regionOptions.indexOf("FULL") !== -1) {
@@ -702,6 +706,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const variableOptions = variableOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType];
     var variableDefault;
     if (variableOptions.indexOf("TMP") !== -1) {
@@ -807,6 +812,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const fhrOptions = forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var fhrDefault;
     if (fhrOptions.indexOf("24") !== -1) {
@@ -945,6 +951,7 @@ const doCurveParams = function () {
             });
     }
 
+    // these defaults are app-specific and not controlled by the user
     const levelOptions = levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var levelDefault;
     if (levelOptions.indexOf("SFC") !== -1) {
@@ -1075,6 +1082,7 @@ const doCurveParams = function () {
     }
 
     // determine date defaults for dates and curveDates
+    // these defaults are app-specific and not controlled by the user
     var defaultDb = matsCollections["database"].findOne({name: "database"}, {default: 1}).default;
     var dbDateRanges = matsCollections["database"].findOne({name: "database"}, {dates: 1}).dates;
     var defaultDataSource = matsCollections["data-source"].findOne({name: "data-source"}, {default: 1}).default;

--- a/apps/met-upperair/server/main.js
+++ b/apps/met-upperair/server/main.js
@@ -481,18 +481,12 @@ const doCurveParams = function () {
         );
     }
 
-    var defaultGroup;
-    var defaultDB;
-    if (Object.keys(dbGroupMap).indexOf("NOAA NCEP") !== -1 && dbGroupMap["NOAA NCEP"].indexOf("mv_gfs_grid2grid_metplus") !== -1) {
-        // special default parameters for the NWS METexpress
-        defaultGroup = "NOAA NCEP";
-        defaultDB = "mv_gfs_grid2grid_metplus";
-    } else {
-        // default to the GSL g2g database if it exists, otherwise default to whatever is first alphabetically
-        defaultGroup = (Object.keys(dbGroupMap).indexOf("NO GROUP") !== -1) ? "NO GROUP" : Object.keys(dbGroupMap)[0];
-        defaultDB = (dbGroupMap[defaultGroup].indexOf("mv_gsl_global_g2g") !== -1) ? "mv_gsl_global_g2g" : dbGroupMap[defaultGroup][0];
-    }
-    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf("GFS") !== -1) ? "GFS" : Object.keys(modelOptionsMap[defaultDB])[0];
+    var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
+    var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
+    var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
+    var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
+    var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
+    var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -1376,30 +1370,8 @@ Meteor.startup(function () {
 
     // create list of tables we need to monitor for update
     const mdr = new matsTypes.MetaDataDBRecord("sumPool", "mats_metadata", ['upperair_mats_metadata', 'upperair_database_groups']);
-    const appCurveParams = [
-        "label",
-        "group",
-        "database",
-        "data-source",
-        "plot-type",
-        "region",
-        "statistic",
-        "variable",
-        "interp-method",
-        "scale",
-        "forecast-length",
-        "dieoff-type",
-        "valid-time",
-        "utc-cycle-start",
-        "average",
-        "level",
-        "description",
-        "x-axis-parameter",
-        "y-axis-parameter",
-        "curve-dates"
-    ];
     try {
-        matsMethods.resetApp({ appPools: allPools, appCurveParams: appCurveParams, appMdr: mdr, appType: matsTypes.AppTypes.metexpress, app: 'met-upperair', title: "MET Upper Air", group: "METexpress"});
+        matsMethods.resetApp({appPools: allPools, appMdr: mdr, appType: matsTypes.AppTypes.metexpress});
     } catch (error) {
         console.log(error.message);
     }

--- a/apps/met-upperair/server/main.js
+++ b/apps/met-upperair/server/main.js
@@ -480,13 +480,16 @@ const doCurveParams = function () {
             }
         );
     }
-
+    // get the default group, db, and model that were specified in the settings file. If none exist, take
+    // the first available option for each in the selector.
     var requestedGroup = matsCollections.Settings.findOne({}).appDefaultGroup;
     var defaultGroup = (Object.keys(dbGroupMap).indexOf(requestedGroup) !== -1) ? requestedGroup : Object.keys(dbGroupMap)[0];
     var requestedDB = matsCollections.Settings.findOne({}).appDefaultDB;
     var defaultDB = (dbGroupMap[defaultGroup].indexOf(requestedDB) !== -1) ? requestedDB : dbGroupMap[defaultGroup][0];
     var requestedModel = matsCollections.Settings.findOne({}).appDefaultModel;
     var defaultModel = (Object.keys(modelOptionsMap[defaultDB]).indexOf(requestedModel) !== -1) ? requestedModel : Object.keys(modelOptionsMap[defaultDB])[0];
+
+    // these defaults are app-specific and not controlled by the user
     var defaultPlotType = matsTypes.PlotTypes.timeSeries;
     var defaultStatistic = Object.keys(statisticOptionsMap[defaultDB][defaultModel][defaultPlotType])[0];
     var defaultStatType = masterStatsValuesMap[defaultStatistic][0];
@@ -625,6 +628,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const regionOptions = regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(regionModelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var regionDefault;
     if (regionOptions.indexOf("FULL") !== -1) {
@@ -702,6 +706,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const variableOptions = variableOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType];
     var variableDefault;
     if (variableOptions.indexOf("TMP") !== -1) {
@@ -807,6 +812,7 @@ const doCurveParams = function () {
         }
     }
 
+    // these defaults are app-specific and not controlled by the user
     const fhrOptions = forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(forecastLengthOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var fhrDefault;
     if (fhrOptions.indexOf("24") !== -1) {
@@ -945,6 +951,7 @@ const doCurveParams = function () {
             });
     }
 
+    // these defaults are app-specific and not controlled by the user
     const levelOptions = levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType][Object.keys(levelOptionsMap[defaultDB][defaultModel][defaultPlotType][defaultStatType])[0]];
     var levelDefault;
     if (levelOptions.indexOf("P500") !== -1) {
@@ -1075,6 +1082,7 @@ const doCurveParams = function () {
     }
 
     // determine date defaults for dates and curveDates
+    // these defaults are app-specific and not controlled by the user
     var defaultDb = matsCollections["database"].findOne({name: "database"}, {default: 1}).default;
     var dbDateRanges = matsCollections["database"].findOne({name: "database"}, {dates: 1}).dates;
     var defaultDataSource = matsCollections["data-source"].findOne({name: "data-source"}, {default: 1}).default;


### PR DESCRIPTION
I have moved the METexpress default group, db, and models to the settings.json files (remember to pull the development branch of mats-settings if you want to run locally!), and removed redundancies that existed between the settings files and the main.js files (some parameters were defined needlessly in both places, and the main.js versions were wrongly taking precedence). Closes #47.