### PR TITLE
Feature error handling

### DIFF
--- a/apps/met-airquality/server/dataFunctions/data_contour.js
+++ b/apps/met-airquality/server/dataFunctions/data_contour.js
@@ -232,19 +232,22 @@ dataContour = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
+
+    // parse any errors from the python code
+    if (queryResult.error[0] !== undefined && queryResult.error[0] !== "") {
+        if (queryResult.error[0] === matsTypes.Messages.NO_DATA_FOUND) {
             // this is NOT an error just a no data condition
             dataFoundForCurve = false;
         } else {
             // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            if (error.includes('Unknown column')) {
-                throw new Error("INFO:  The statistic/variable combination [" + statistic + " and " + variable + "] is not supported by the database for the model/regions [" + model + " and " + regions + "].");
-            } else {
-                throw new Error(error);
-            }
+            error += "Error from verification query: <br>" + queryResult.error[0] + "<br> query: <br>" + statement + "<br>";
+            throw new Error(error);
         }
+    }
+
+    if (!dataFoundForCurve) {
+        // we found no data for any curves so don't bother proceeding
+        throw new Error("INFO:  No valid data for any curves.");
     }
 
     var postQueryStartMoment = moment();

--- a/apps/met-airquality/server/dataFunctions/data_dieoff.js
+++ b/apps/met-airquality/server/dataFunctions/data_dieoff.js
@@ -247,17 +247,21 @@ dataDieOff = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-airquality/server/dataFunctions/data_histogram.js
+++ b/apps/met-airquality/server/dataFunctions/data_histogram.js
@@ -246,17 +246,21 @@ dataHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-airquality/server/dataFunctions/data_series.js
+++ b/apps/met-airquality/server/dataFunctions/data_series.js
@@ -244,17 +244,21 @@ dataSeries = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-airquality/server/dataFunctions/data_threshold.js
+++ b/apps/met-airquality/server/dataFunctions/data_threshold.js
@@ -236,17 +236,21 @@ dataThreshold = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-airquality/server/dataFunctions/data_validtime.js
+++ b/apps/met-airquality/server/dataFunctions/data_validtime.js
@@ -229,17 +229,21 @@ dataValidTime = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-anomalycor/server/dataFunctions/data_contour.js
+++ b/apps/met-anomalycor/server/dataFunctions/data_contour.js
@@ -230,19 +230,22 @@ dataContour = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
+
+    // parse any errors from the python code
+    if (queryResult.error[0] !== undefined && queryResult.error[0] !== "") {
+        if (queryResult.error[0] === matsTypes.Messages.NO_DATA_FOUND) {
             // this is NOT an error just a no data condition
             dataFoundForCurve = false;
         } else {
             // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            if (error.includes('Unknown column')) {
-                throw new Error("INFO:  The statistic/variable combination [" + statistic + " and " + variable + "] is not supported by the database for the model/regions [" + model + " and " + regions + "].");
-            } else {
-                throw new Error(error);
-            }
+            error += "Error from verification query: <br>" + queryResult.error[0] + "<br> query: <br>" + statement + "<br>";
+            throw new Error(error);
         }
+    }
+
+    if (!dataFoundForCurve) {
+        // we found no data for any curves so don't bother proceeding
+        throw new Error("INFO:  No valid data for any curves.");
     }
 
     var postQueryStartMoment = moment();

--- a/apps/met-anomalycor/server/dataFunctions/data_dieoff.js
+++ b/apps/met-anomalycor/server/dataFunctions/data_dieoff.js
@@ -242,17 +242,21 @@ dataDieOff = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-anomalycor/server/dataFunctions/data_histogram.js
+++ b/apps/met-anomalycor/server/dataFunctions/data_histogram.js
@@ -241,17 +241,21 @@ dataHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-anomalycor/server/dataFunctions/data_profile.js
+++ b/apps/met-anomalycor/server/dataFunctions/data_profile.js
@@ -224,17 +224,21 @@ dataProfile = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-anomalycor/server/dataFunctions/data_series.js
+++ b/apps/met-anomalycor/server/dataFunctions/data_series.js
@@ -239,17 +239,21 @@ dataSeries = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-anomalycor/server/dataFunctions/data_validtime.js
+++ b/apps/met-anomalycor/server/dataFunctions/data_validtime.js
@@ -224,17 +224,21 @@ dataValidTime = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-cyclone/server/dataFunctions/data_dieoff.js
+++ b/apps/met-cyclone/server/dataFunctions/data_dieoff.js
@@ -215,17 +215,21 @@ dataDieOff = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-cyclone/server/dataFunctions/data_histogram.js
+++ b/apps/met-cyclone/server/dataFunctions/data_histogram.js
@@ -214,17 +214,21 @@ dataHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-cyclone/server/dataFunctions/data_series.js
+++ b/apps/met-cyclone/server/dataFunctions/data_series.js
@@ -212,17 +212,21 @@ dataSeries = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-cyclone/server/dataFunctions/data_validtime.js
+++ b/apps/met-cyclone/server/dataFunctions/data_validtime.js
@@ -197,17 +197,21 @@ dataValidTime = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-cyclone/server/dataFunctions/data_yeartoyear.js
+++ b/apps/met-cyclone/server/dataFunctions/data_yeartoyear.js
@@ -195,17 +195,21 @@ dataYearToYear = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-ensemble/server/dataFunctions/data_dieoff.js
+++ b/apps/met-ensemble/server/dataFunctions/data_dieoff.js
@@ -216,17 +216,21 @@ dataDieOff = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-ensemble/server/dataFunctions/data_ensemble_histogram.js
+++ b/apps/met-ensemble/server/dataFunctions/data_ensemble_histogram.js
@@ -224,17 +224,21 @@ dataEnsembleHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-ensemble/server/dataFunctions/data_histogram.js
+++ b/apps/met-ensemble/server/dataFunctions/data_histogram.js
@@ -215,17 +215,21 @@ dataHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-ensemble/server/dataFunctions/data_perfDiagram.js
+++ b/apps/met-ensemble/server/dataFunctions/data_perfDiagram.js
@@ -207,17 +207,21 @@ dataPerformanceDiagram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-ensemble/server/dataFunctions/data_reliability.js
+++ b/apps/met-ensemble/server/dataFunctions/data_reliability.js
@@ -207,17 +207,21 @@ dataReliability = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-ensemble/server/dataFunctions/data_roc.js
+++ b/apps/met-ensemble/server/dataFunctions/data_roc.js
@@ -207,17 +207,21 @@ dataROC = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-ensemble/server/dataFunctions/data_series.js
+++ b/apps/met-ensemble/server/dataFunctions/data_series.js
@@ -213,17 +213,21 @@ dataSeries = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-ensemble/server/dataFunctions/data_validtime.js
+++ b/apps/met-ensemble/server/dataFunctions/data_validtime.js
@@ -198,17 +198,21 @@ dataValidTime = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-object/server/dataFunctions/data_dieoff.js
+++ b/apps/met-object/server/dataFunctions/data_dieoff.js
@@ -284,17 +284,21 @@ dataDieOff = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-object/server/dataFunctions/data_histogram.js
+++ b/apps/met-object/server/dataFunctions/data_histogram.js
@@ -283,17 +283,21 @@ dataHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-object/server/dataFunctions/data_series.js
+++ b/apps/met-object/server/dataFunctions/data_series.js
@@ -281,17 +281,21 @@ dataSeries = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-object/server/dataFunctions/data_threshold.js
+++ b/apps/met-object/server/dataFunctions/data_threshold.js
@@ -273,17 +273,21 @@ dataThreshold = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-object/server/dataFunctions/data_validtime.js
+++ b/apps/met-object/server/dataFunctions/data_validtime.js
@@ -266,17 +266,21 @@ dataValidTime = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-precip/server/dataFunctions/data_contour.js
+++ b/apps/met-precip/server/dataFunctions/data_contour.js
@@ -243,19 +243,22 @@ dataContour = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
+
+    // parse any errors from the python code
+    if (queryResult.error[0] !== undefined && queryResult.error[0] !== "") {
+        if (queryResult.error[0] === matsTypes.Messages.NO_DATA_FOUND) {
             // this is NOT an error just a no data condition
             dataFoundForCurve = false;
         } else {
             // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            if (error.includes('Unknown column')) {
-                throw new Error("INFO:  The statistic/variable combination [" + statistic + " and " + variable + "] is not supported by the database for the model/regions [" + model + " and " + regions + "].");
-            } else {
-                throw new Error(error);
-            }
+            error += "Error from verification query: <br>" + queryResult.error[0] + "<br> query: <br>" + statement + "<br>";
+            throw new Error(error);
         }
+    }
+
+    if (!dataFoundForCurve) {
+        // we found no data for any curves so don't bother proceeding
+        throw new Error("INFO:  No valid data for any curves.");
     }
 
     var postQueryStartMoment = moment();

--- a/apps/met-precip/server/dataFunctions/data_dieoff.js
+++ b/apps/met-precip/server/dataFunctions/data_dieoff.js
@@ -257,17 +257,21 @@ dataDieOff = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-precip/server/dataFunctions/data_gridscale.js
+++ b/apps/met-precip/server/dataFunctions/data_gridscale.js
@@ -243,17 +243,21 @@ dataGridScale = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-precip/server/dataFunctions/data_histogram.js
+++ b/apps/met-precip/server/dataFunctions/data_histogram.js
@@ -256,17 +256,21 @@ dataHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-precip/server/dataFunctions/data_series.js
+++ b/apps/met-precip/server/dataFunctions/data_series.js
@@ -254,17 +254,21 @@ dataSeries = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-precip/server/dataFunctions/data_threshold.js
+++ b/apps/met-precip/server/dataFunctions/data_threshold.js
@@ -246,17 +246,21 @@ dataThreshold = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-precip/server/dataFunctions/data_validtime.js
+++ b/apps/met-precip/server/dataFunctions/data_validtime.js
@@ -239,17 +239,21 @@ dataValidTime = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-surface/server/dataFunctions/data_contour.js
+++ b/apps/met-surface/server/dataFunctions/data_contour.js
@@ -235,15 +235,22 @@ dataContour = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
+
+    // parse any errors from the python code
+    if (queryResult.error[0] !== undefined && queryResult.error[0] !== "") {
+        if (queryResult.error[0] === matsTypes.Messages.NO_DATA_FOUND) {
             // this is NOT an error just a no data condition
             dataFoundForCurve = false;
         } else {
             // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
+            error += "Error from verification query: <br>" + queryResult.error[0] + "<br> query: <br>" + statement + "<br>";
             throw new Error(error);
         }
+    }
+
+    if (!dataFoundForCurve) {
+        // we found no data for any curves so don't bother proceeding
+        throw new Error("INFO:  No valid data for any curves.");
     }
 
     var postQueryStartMoment = moment();

--- a/apps/met-surface/server/dataFunctions/data_dieoff.js
+++ b/apps/met-surface/server/dataFunctions/data_dieoff.js
@@ -249,17 +249,21 @@ dataDieOff = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-surface/server/dataFunctions/data_histogram.js
+++ b/apps/met-surface/server/dataFunctions/data_histogram.js
@@ -241,17 +241,21 @@ dataHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-surface/server/dataFunctions/data_series.js
+++ b/apps/met-surface/server/dataFunctions/data_series.js
@@ -246,17 +246,21 @@ dataSeries = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-surface/server/dataFunctions/data_validtime.js
+++ b/apps/met-surface/server/dataFunctions/data_validtime.js
@@ -231,17 +231,21 @@ dataValidTime = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-upperair/server/dataFunctions/data_contour.js
+++ b/apps/met-upperair/server/dataFunctions/data_contour.js
@@ -235,15 +235,22 @@ dataContour = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
+
+    // parse any errors from the python code
+    if (queryResult.error[0] !== undefined && queryResult.error[0] !== "") {
+        if (queryResult.error[0] === matsTypes.Messages.NO_DATA_FOUND) {
             // this is NOT an error just a no data condition
             dataFoundForCurve = false;
         } else {
             // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
+            error += "Error from verification query: <br>" + queryResult.error[0] + "<br> query: <br>" + statement + "<br>";
             throw new Error(error);
         }
+    }
+
+    if (!dataFoundForCurve) {
+        // we found no data for any curves so don't bother proceeding
+        throw new Error("INFO:  No valid data for any curves.");
     }
 
     var postQueryStartMoment = moment();

--- a/apps/met-upperair/server/dataFunctions/data_dieoff.js
+++ b/apps/met-upperair/server/dataFunctions/data_dieoff.js
@@ -249,17 +249,21 @@ dataDieOff = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-upperair/server/dataFunctions/data_histogram.js
+++ b/apps/met-upperair/server/dataFunctions/data_histogram.js
@@ -241,17 +241,21 @@ dataHistogram = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-upperair/server/dataFunctions/data_profile.js
+++ b/apps/met-upperair/server/dataFunctions/data_profile.js
@@ -231,17 +231,21 @@ dataProfile = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-upperair/server/dataFunctions/data_series.js
+++ b/apps/met-upperair/server/dataFunctions/data_series.js
@@ -246,17 +246,21 @@ dataSeries = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {

--- a/apps/met-upperair/server/dataFunctions/data_validtime.js
+++ b/apps/met-upperair/server/dataFunctions/data_validtime.js
@@ -231,17 +231,21 @@ dataValidTime = function (plotParams, plotFunction) {
         e.message = "Error in queryDB: " + e.message + " for statement: " + statement;
         throw new Error(e.message);
     }
-    if (queryResult.error !== undefined && queryResult.error !== "") {
-        if (queryResult.error === matsTypes.Messages.NO_DATA_FOUND) {
-            // this is NOT an error just a no data condition
-            dataFoundForCurve = false;
+
+    // parse any errors from the python code
+    for (curveIndex = 0; curveIndex < curvesLength; curveIndex++) {
+        if (queryResult.error[curveIndex] !== undefined && queryResult.error[curveIndex] !== "") {
+            if (queryResult.error[curveIndex] === matsTypes.Messages.NO_DATA_FOUND) {
+                // this is NOT an error just a no data condition
+                dataFoundForCurve = false;
+            } else {
+                // this is an error returned by the mysql database
+                error += "Error from verification query: <br>" + queryResult.error[curveIndex] + "<br> query: <br>" + statement + "<br>";
+                throw (new Error(error));
+            }
         } else {
-            // this is an error returned by the mysql database
-            error += "Error from verification query: <br>" + queryResult.error + "<br> query: <br>" + statement + "<br>";
-            throw (new Error(error));
+            dataFoundForAnyCurve = true;
         }
-    } else {
-        dataFoundForAnyCurve = true;
     }
 
     if (!dataFoundForAnyCurve) {


### PR DESCRIPTION
This pull request fixes a bug in METexpress where the apps declare "No Data For All Curves" if any of the curves has no data. (Issue #88). There's two basic changes: self.error has become an array in [python_query_util.py](https://github.com/dtcenter/MATScommon/compare/b64dd673b3ae9dd4ff892b35939dc31974e2baaf...5dad94a007d14153bb941076b04cbf692167a184#diff-29cccd61f4704416bb29eea847691c8d4ece5fe23a1495cc92fc6f42f8997ff9) (so each curve can have its own error message and not be stuck with the error message of the final curve), and all of the app data routines have been changed to reference the error returned from the python code as an array.