### PR TITLE
Update dockerfile to a debian based node image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
+    target-branch: "development" # raise PRs for version updates to GHA against the `development` branch

--- a/.github/workflows/trivy-repo-analysis.yml
+++ b/.github/workflows/trivy-repo-analysis.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,34 +19,8 @@ COPY MATScommon /MATScommon
 RUN bash ${SCRIPTS_FOLDER}/build-meteor-bundle.sh
 
 
-# Install OS build dependencies
-FROM node:14-alpine AS native-builder
-
-ENV APP_FOLDER=/usr/app
-ENV APP_BUNDLE_FOLDER=${APP_FOLDER}/bundle
-ENV SCRIPTS_FOLDER /docker
-
-# Install OS build dependencies, which stay with this intermediate image but don’t become part of the final published image
-RUN apk --no-cache add \
-    bash \
-    g++ \
-    make \
-    python3
-
-# Copy in build scripts & entrypoint
-COPY --from=meteor-builder $SCRIPTS_FOLDER $SCRIPTS_FOLDER/
-
-# Copy in app bundle
-COPY --from=meteor-builder /opt/bundle $APP_BUNDLE_FOLDER/
-
-# Build the native dependencies
-# NOTE - the randyp_mats-common atmosphere package pulls in a native npm couchbase dependency
-# so we need to force an npm rebuild in the node_modules directory there as well
-RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh
-
-
 # Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html
-FROM node:14-alpine AS production
+FROM node:14-bullseye-slim AS production
 
 # Set Build ARGS
 ARG APPNAME
@@ -55,19 +29,21 @@ ARG COMMITBRANCH=development
 ARG COMMITSHA
 ARG METCALCPYVER=develop
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Install runtime dependencies
-RUN apk --no-cache add \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     git \
     ca-certificates \
-    mariadb \
     python3 \
-    py3-numpy \
-    py3-scipy \
-    py3-pandas \
-    py3-pip \
+    python3-numpy \
+    python3-scipy \
+    python3-pandas \
+    python3-pip \
+    python3-pymysql \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && pip3 --no-cache-dir install \
-        pymysql \
         metcalcpy@git+https://github.com/dtcenter/METcalcpy.git@${METCALCPYVER}
 
 # Set Environment
@@ -83,11 +59,11 @@ ENV VERSION=${BUILDVER}
 ENV BRANCH=${COMMITBRANCH}
 ENV COMMIT=${COMMITSHA}
 
-# Copy in helper scripts with the built and installed dependencies from the previous image
-COPY --from=native-builder ${SCRIPTS_FOLDER} ${SCRIPTS_FOLDER}/
+# Copy in helper scripts from the previous image
+COPY --from=meteor-builder ${SCRIPTS_FOLDER} ${SCRIPTS_FOLDER}/
 
-# Copy in app bundle with the built and installed dependencies from the previous image
-COPY --from=native-builder ${APP_BUNDLE_FOLDER} ${APP_BUNDLE_FOLDER}/
+# Copy in app bundle from the previous image
+COPY --from=meteor-builder /opt/bundle ${APP_BUNDLE_FOLDER}/
 
 # We want to use our own launcher script
 COPY container-scripts/run_app.sh ${APP_FOLDER}/
@@ -99,6 +75,10 @@ RUN mkdir -p ${SETTINGS_DIR} \
     && touch ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache \
     && chown node:node ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache \
     && chmod 644 ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache
+
+# Install the Meteor app's NPM dependencies and update the OS in the container
+RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh
+RUN apt-get update && apt-get -y upgrade && apt-get clean && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 EXPOSE ${PORT}
 USER node


### PR DESCRIPTION
Update our container image to be based on debian-slim similarly to MATS. Additionally, update our GitHub Actions to match MATS.

Closes #122 