### PR TITLE
Fix our container image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,18 +1,26 @@
-.git*
-.idea
-.vscode
-README*
-RELEASE.txt
-appProduction*
-bundle*
-node_modules
-cache*
+# Tooling artifacts
+**/.git
+**/.github
+**/.idea
+**/.vscode
+**/.fleet
+
+# Meteor artifacts
+**/bundle
+**/.npm
+**/.meteor/local
+**/node_modules
+
+# METexpress artifacts
+**/*.md
 container_deployment
-home
-logs
+docs
 scripts
-server_configuration_files
-static
-tests
-tmp*
-METexpress
+**/tests
+build.sh
+LICENSE.md
+
+# Development files
+**/tmp*
+cache*
+logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      packages: write
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     strategy:
-      # fail-fast: true  # FIXME: Reactivate fail-fast once our image size is under control
+      fail-fast: true
       matrix:
         app: 
           - met-airquality
@@ -105,19 +105,18 @@ jobs:
             --build-arg COMMITSHA=${{ github.sha }} \
             -t ${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }} \
             .
-      # FIXME: Reactivate image scanning once we've determined why the image size has blown up
-      # - name: Scan image with Trivy
-      #   uses: aquasecurity/trivy-action@master
-      #   with:
-      #     image-ref: '${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}'
-      #     format: 'sarif'
-      #     output: 'trivy-results-${{ env.APP_LOWERCASE }}.sarif'
-      #     ignore-unfixed: true
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}'
+          format: 'sarif'
+          output: 'trivy-results-${{ env.APP_LOWERCASE }}.sarif'
+          ignore-unfixed: true
 
-      # - name: Upload Trivy scan results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@v2
-      #   with:
-      #     sarif_file: 'trivy-results-${{ env.APP_LOWERCASE }}.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results-${{ env.APP_LOWERCASE }}.sarif'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ ENV METEOR_PACKAGE_DIRS=/MATScommon/meteor_packages
 # Assume we're passed the repo root as build context
 COPY apps/${APPNAME}/package*.json ${APP_SOURCE_FOLDER}/
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends cmake && \
-  bash ${SCRIPTS_FOLDER}/build-app-npm-dependencies.sh
+RUN bash ${SCRIPTS_FOLDER}/build-app-npm-dependencies.sh
 
 # Copy app & MATScommon library source into container
 COPY apps/${APPNAME} ${APP_SOURCE_FOLDER}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN bash ${SCRIPTS_FOLDER}/build-app-npm-dependencies.sh
 COPY apps/${APPNAME} ${APP_SOURCE_FOLDER}/
 COPY MATScommon /MATScommon
 
+# If this fails with the mention that cmake is needed to build a dependency,
+# double check the `MATScommon/meteor_packages/mats-common/.npm/package/npm-shrinkwrap.json
+# file for any OS-specific dependencies. If we allow Meteor to build the Couchbase SDK, it
+# will blow up our image size. 
 RUN bash ${SCRIPTS_FOLDER}/build-meteor-bundle.sh
 
 


### PR DESCRIPTION
This PR does a few things:

* Remove `cmake` from our `Dockerfile` to prevent Couchbase from being rebuilt by Meteor/NPM. If Couchbase is built from source it takes up a large amount of space in the image.
* Removes some OS-specific Couchbase dependencies that made it into MATScommon. 
* Update the `.dockerignore` to match MATS - it appears to be important to exclude MATScommon's `.npm/packages/npm-shrinkwrap.json` file from the docker container build. 
* Removes workarounds that were added to CI.
 
Closes #132 