### PR TITLE
Propagate MATS CI changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
     target-branch: "development" # raise PRs for version updates to GHA against the `development` branch
+    assignees:
+      - "ian-noaa"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: "Build METexpress"
 on:
   push:
     branches: [main, development]

--- a/.github/workflows/prune-untagged-images.yml
+++ b/.github/workflows/prune-untagged-images.yml
@@ -26,7 +26,7 @@ jobs:
         uses: snok/container-retention-policy@v2.1.2
         with:
           image-names: metexpress/development/${{ matrix.app }}
-          cut-off: 1 day ago MST
+          cut-off: 1 week ago MST
           account-type: org
           org-name: dtcenter
           untagged-only: true


### PR DESCRIPTION
We want to have consistent image retention times. Additionally, assign dependabot CI updates to myself so I know to merge them.