### PR TITLE
Feature met cyclone improvements

### DIFF
--- a/apps/met-cyclone/server/dataFunctions/data_dieoff.js
+++ b/apps/met-cyclone/server/dataFunctions/data_dieoff.js
@@ -22,7 +22,7 @@ dataDieoff = function (plotParams, plotFunction) {
     completeness: plotParams.completeness,
     outliers: plotParams.outliers,
     hideGaps: plotParams.noGapsCheck,
-    hasLevels: false,
+    hasLevels: true,
   };
   const dataRequests = {}; // used to store data queries
   const queryArray = [];
@@ -100,7 +100,7 @@ dataDieoff = function (plotParams, plotFunction) {
       thresholdClause = `and h.fcst_thresh = '${threshold}'`;
     } else if (statLineType === "precalculated") {
       // set up fields specific to precalculated stats
-      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid) order by unix_timestamp(ld.fcst_valid)) as sub_data`;
+      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid), ';', h.storm_id order by unix_timestamp(ld.fcst_valid), h.storm_id) as sub_data`;
       statHeaderType = "tcst_header";
       [, lineDataType] = statisticOptionsMap[statistic];
       modelClause = `and h.amodel = '${model}'`;

--- a/apps/met-cyclone/server/dataFunctions/data_histogram.js
+++ b/apps/met-cyclone/server/dataFunctions/data_histogram.js
@@ -20,7 +20,7 @@ dataHistogram = function (plotParams, plotFunction) {
     completeness: plotParams.completeness,
     outliers: plotParams.outliers,
     hideGaps: plotParams.noGapsCheck,
-    hasLevels: false,
+    hasLevels: true,
   };
   const alreadyMatched = false;
   const dataRequests = {}; // used to store data queries
@@ -102,7 +102,7 @@ dataHistogram = function (plotParams, plotFunction) {
       thresholdClause = `and h.fcst_thresh = '${threshold}'`;
     } else if (statLineType === "precalculated") {
       // set up fields specific to precalculated stats
-      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid) order by unix_timestamp(ld.fcst_valid)) as sub_data`;
+      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid), ';', h.storm_id order by unix_timestamp(ld.fcst_valid), h.storm_id) as sub_data`;
       statHeaderType = "tcst_header";
       [, lineDataType] = statisticOptionsMap[statistic];
       modelClause = `and h.amodel = '${model}'`;

--- a/apps/met-cyclone/server/dataFunctions/data_series.js
+++ b/apps/met-cyclone/server/dataFunctions/data_series.js
@@ -22,7 +22,7 @@ dataSeries = function (plotParams, plotFunction) {
     completeness: plotParams.completeness,
     outliers: plotParams.outliers,
     hideGaps: plotParams.noGapsCheck,
-    hasLevels: false,
+    hasLevels: true,
   };
   const dataRequests = {}; // used to store data queries
   const queryArray = [];
@@ -103,7 +103,7 @@ dataSeries = function (plotParams, plotFunction) {
       thresholdClause = `and h.fcst_thresh = '${threshold}'`;
     } else if (statLineType === "precalculated") {
       // set up fields specific to precalculated stats
-      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid) order by unix_timestamp(ld.fcst_valid)) as sub_data`;
+      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid), ';', h.storm_id order by unix_timestamp(ld.fcst_valid), h.storm_id) as sub_data`;
       statHeaderType = "tcst_header";
       [, lineDataType] = statisticOptionsMap[statistic];
       modelClause = `and h.amodel = '${model}'`;

--- a/apps/met-cyclone/server/dataFunctions/data_validtime.js
+++ b/apps/met-cyclone/server/dataFunctions/data_validtime.js
@@ -22,7 +22,7 @@ dataValidTime = function (plotParams, plotFunction) {
     completeness: plotParams.completeness,
     outliers: plotParams.outliers,
     hideGaps: plotParams.noGapsCheck,
-    hasLevels: false,
+    hasLevels: true,
   };
   const dataRequests = {}; // used to store data queries
   const queryArray = [];
@@ -100,7 +100,7 @@ dataValidTime = function (plotParams, plotFunction) {
       thresholdClause = `and h.fcst_thresh = '${threshold}'`;
     } else if (statLineType === "precalculated") {
       // set up fields specific to precalculated stats
-      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid) order by unix_timestamp(ld.fcst_valid)) as sub_data`;
+      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid), ';', h.storm_id order by unix_timestamp(ld.fcst_valid), h.storm_id) as sub_data`;
       statHeaderType = "tcst_header";
       [, lineDataType] = statisticOptionsMap[statistic];
       modelClause = `and h.amodel = '${model}'`;

--- a/apps/met-cyclone/server/dataFunctions/data_yeartoyear.js
+++ b/apps/met-cyclone/server/dataFunctions/data_yeartoyear.js
@@ -21,7 +21,7 @@ dataYearToYear = function (plotParams, plotFunction) {
     completeness: plotParams.completeness,
     outliers: plotParams.outliers,
     hideGaps: plotParams.noGapsCheck,
-    hasLevels: false,
+    hasLevels: true,
   };
   const dataRequests = {}; // used to store data queries
   const queryArray = [];
@@ -99,7 +99,7 @@ dataYearToYear = function (plotParams, plotFunction) {
       thresholdClause = `and h.fcst_thresh = '${threshold}'`;
     } else if (statLineType === "precalculated") {
       // set up fields specific to precalculated stats
-      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid) order by unix_timestamp(ld.fcst_valid)) as sub_data`;
+      statisticClause = `avg(${statisticOptionsMap[statistic][2]}) as stat, group_concat(distinct ${statisticOptionsMap[statistic][2]}, ';', 9999, ';', unix_timestamp(ld.fcst_valid), ';', h.storm_id order by unix_timestamp(ld.fcst_valid), h.storm_id) as sub_data`;
       statHeaderType = "tcst_header";
       [, lineDataType] = statisticOptionsMap[statistic];
       modelClause = `and h.amodel = '${model}'`;

--- a/apps/met-cyclone/server/main.js
+++ b/apps/met-cyclone/server/main.js
@@ -299,14 +299,14 @@ const doCurveParams = function () {
       "Model-truth distance to land (nm)": [
         "precalculated",
         "line_data_tcmpr",
-        "ld.adland-ld.bdland",
+        "if(ld.adland != -9999 and ld.bdland != -9999,ld.adland-ld.bdland,null)",
       ],
       "Model MSLP (mb)": ["precalculated", "line_data_tcmpr", "ld.amslp"],
       "Truth MSLP (mb)": ["precalculated", "line_data_tcmpr", "ld.bmslp"],
       "Model-truth MSLP (mb)": [
         "precalculated",
         "line_data_tcmpr",
-        "ld.amslp-ld.bmslp",
+        "if(ld.amslp != -9999 and ld.bmslp != -9999,ld.amslp-ld.bmslp,null)",
       ],
       "Model maximum wind speed (kts)": [
         "precalculated",
@@ -321,7 +321,7 @@ const doCurveParams = function () {
       "Model-truth maximum wind speed (kts)": [
         "precalculated",
         "line_data_tcmpr",
-        "ld.amax_wind-ld.bmax_wind",
+        "if(ld.amax_wind != -9999 and ld.bmax_wind != -9999,ld.amax_wind-ld.bmax_wind,null)",
       ],
       "Model radius of maximum winds (nm)": [
         "precalculated",
@@ -336,28 +336,28 @@ const doCurveParams = function () {
       "Model-truth radius of maximum winds (nm)": [
         "precalculated",
         "line_data_tcmpr",
-        "ld.amrd-ld.bmrd",
+        "if(ld.amrd != -9999 and ld.bmrd != -9999,ld.amrd-ld.bmrd,null)",
       ],
       "Model eye diameter (nm)": ["precalculated", "line_data_tcmpr", "ld.aeye"],
       "Truth eye diameter (nm)": ["precalculated", "line_data_tcmpr", "ld.beye"],
       "Model-truth eye diameter (nm)": [
         "precalculated",
         "line_data_tcmpr",
-        "ld.aeye-ld.beye",
+        "if(ld.aeye != -9999 and ld.beye != -9999,ld.aeye-ld.beye,null)",
       ],
       "Model storm speed (kts)": ["precalculated", "line_data_tcmpr", "ld.aspeed"],
       "Truth storm speed (kts)": ["precalculated", "line_data_tcmpr", "ld.bspeed"],
       "Model-truth storm speed (kts)": [
         "precalculated",
         "line_data_tcmpr",
-        "ld.aspeed-ld.bspeed",
+        "if(ld.aspeed != -9999 and ld.bspeed != -9999,ld.aspeed-ld.bspeed,null)",
       ],
       "Model storm direction (deg)": ["precalculated", "line_data_tcmpr", "ld.adir"],
       "Truth storm direction (deg)": ["precalculated", "line_data_tcmpr", "ld.bdir"],
       "Model-truth storm direction (deg)": [
         "precalculated",
         "line_data_tcmpr",
-        "ld.adir-ld.bdir",
+        "if(ld.adir != -9999 and ld.bdir != -9999,ld.adir-ld.bdir,null)",
       ],
     },
     line_data_ctc: {


### PR DESCRIPTION
This PR improves the matching algorithm for MET Cyclone by having it match by storm_id as well as time. It also correctly filters out missing values in the MET Cyclone data, and makes error bar thickness customizable.