### PR TITLE
Switch to Docker's build-push-action in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,15 +104,34 @@ jobs:
         run: |
           echo "APP_LOWERCASE=${APP,,}" >> $GITHUB_ENV
 
-      - name: Build image
-        run: |
-          docker build \
-            --build-arg APPNAME=${{ matrix.app }} \
-            --build-arg BUILDVER="${{ env.VERSION }}" \
-            --build-arg COMMITBRANCH=${{ env.BRANCH }} \
-            --build-arg COMMITSHA=${{ github.sha }} \
-            -t ${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }} \
-            .
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build image and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          tags: ${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}
+          build-args: |
+            APPNAME=${{ matrix.app }}
+            BUILDVER=${{ env.VERSION }}
+            COMMITBRANCH=${{ env.BRANCH }}
+            COMMITSHA=${{ github.sha }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
+          cache-to: type=gha,mode=min,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
+          push: true
+          # Disable provenance & sbom generation for single-arch builds as
+          # they confuse the docker client and result in "manifest unknown" errors
+          provenance: false
+          sbom: false
+          
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@master
         with:
@@ -125,14 +144,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results-${{ env.APP_LOWERCASE }}.sarif'
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push image to dev registry
-        run: |
-            docker push ${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}


### PR DESCRIPTION
This way we'll match MATS CI. This should also help speed up builds. Note that provenance & sbom creation are disabled as they appear to create problematic artifacts for single-architecture builds in GHCR.

